### PR TITLE
Fix Page info color

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-800;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
Update page-info color to gray800 (#344054)  in the design